### PR TITLE
[SDK] Easier to use HuffmanEncoder method and additional tests

### DIFF
--- a/FrostySdkTest/FrostySdkTest.csproj
+++ b/FrostySdkTest/FrostySdkTest.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/FrostySdkTest/Utils/HuffmanCodingTests.cs
+++ b/FrostySdkTest/Utils/HuffmanCodingTests.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Frosty.Sdk.IO;
 using Frosty.Sdk.Utils;
+using static Frosty.Sdk.Utils.EncodingResult;
 
 namespace FrostySdkTest.Utils;
 
@@ -21,7 +23,7 @@ public class HuffmanEncodingTests
     /// <param name="compressResults"></param>
     /// <param name="encodedByteSize"></param>
     [TestCaseSource(nameof(s_encodingDecodingTestValues))]
-    public void TextEncodingDecoding(bool compressResults, int encodedByteSize)
+    public void TestEncodingDecoding(bool compressResults, int encodedByteSize)
     {
         string[] texts = { "These are ", "", "some ", "Test Texts", " for tests ", "some ", " these are" };
 
@@ -38,23 +40,7 @@ public class HuffmanEncodingTests
             Assert.That(encodingResult.EncodedTexts, Has.Length.EqualTo(encodedByteSize));
             Assert.That(encodingResult.EncodedTextPositions, Has.Count.EqualTo(texts.Length));
         });
-        HuffmanDecoder decoder = new();
-
-        using (MemoryStream stream = new())
-        {
-            using (DataStream ds = new(stream))
-            {
-                foreach (var val in encodingTree)
-                {
-                    ds.WriteUInt32(val);
-                }
-
-                ds.Position = 0;
-
-                decoder.ReadHuffmanTable(new DataStream(stream), (uint)encodingTree.Count);
-
-            }
-        }
+        HuffmanDecoder decoder = CreateDecoderFromTree(encodingTree);
 
         using (MemoryStream stream = new())
         {
@@ -86,5 +72,95 @@ public class HuffmanEncodingTests
             Assert.That(decoded, Has.Count.EqualTo(texts.Length));
             Assert.That(decoded.ToArray(), Is.EqualTo(texts));
         });
+    }
+
+    private static HuffmanDecoder CreateDecoderFromTree(IList<uint> encodingTree)
+    {
+        HuffmanDecoder decoder = new();
+        using (MemoryStream stream = new())
+        {
+            using (DataStream ds = new(stream))
+            {
+                foreach (var val in encodingTree)
+                {
+                    ds.WriteUInt32(val);
+                }
+
+                ds.Position = 0;
+
+                decoder.ReadHuffmanTable(new DataStream(stream), (uint)encodingTree.Count);
+            }
+        }
+        return decoder;
+    }
+
+    [Test]
+    public void TestWithTextAsKey()
+    {
+        string[] texts = {"Some ", "more ", "Text that might be ", "stored together ", "or whatever ", "these are only ", "for test usage"};
+
+        HuffmanEncoder encoder = new();
+        var encodingTree = encoder.BuildHuffmanEncodingTree(texts);
+
+        HuffmanEncodedTextArray<string> encodingResult = encoder.EncodeTexts(texts.Select(
+            x => new Tuple<string, string>(x,x)).ToList(), false);
+
+        HuffmanDecoder decoder = CreateDecoderFromTree(encodingTree);
+
+        using (MemoryStream stream = new())
+        {
+            using (DataStream ds = new(stream))
+            {
+
+                var byteArray = encodingResult.EncodedTexts;
+
+                ds.Write(byteArray);
+                ds.Position = 0;
+
+                decoder.ReadOddSizedEncodedData(ds, (uint)byteArray.Length);
+            }
+        }
+
+        Dictionary<string, int> lookupMap = new (encodingResult.EncodedTextPositions.Select(t => KeyValuePair.Create(t.Identifier, t.Position)).ToList());
+
+        foreach(string originalText in texts)
+        {
+            int bitOffset = lookupMap[originalText];
+            string readFromDecoder = decoder.ReadHuffmanEncodedString(bitOffset);
+
+            Assert.AreEqual(originalText, readFromDecoder);
+        }
+    }
+
+    [Test]
+    public void TestAllInOneMethod()
+    {
+        var texts = new List<string> { "I'm a mog, half man, half dog", "I'm my own best friend!", "Oh yes, now they are small and cute and cuddly", " and next they suddenly have teeth", " and there is a thousand of them" };
+
+        var encodingResult = HuffmanEncoder.Encode(texts);
+
+        HuffmanDecoder decoder = CreateDecoderFromTree(encodingResult.EncodingTree);
+        using (MemoryStream stream = new())
+        {
+            using (DataStream ds = new(stream))
+            {
+
+                var byteArray = encodingResult.EncodedTexts;
+
+                ds.Write(byteArray);
+                ds.Position = 0;
+
+                decoder.ReadOddSizedEncodedData(ds, (uint)byteArray.Length);
+            }
+        }
+
+        var lookupMap = encodingResult.GetTextPositionsDictionary();
+        foreach (string originalText in texts)
+        {
+            int bitOffset = lookupMap[originalText];
+            string readFromDecoder = decoder.ReadHuffmanEncodedString(bitOffset);
+
+            Assert.AreEqual(originalText, readFromDecoder);
+        }
     }
 }


### PR DESCRIPTION
New easier to use all in one Encode method in the Huffman encoder and some additional documentation.
Beware: That new method is really slow, i used a hashset and iterate twice over that one with linq or something.