### PR TITLE
Fix windows symlink admin rights

### DIFF
--- a/FrostyModSupport/Archive/InstallChunkWriter.cs
+++ b/FrostyModSupport/Archive/InstallChunkWriter.cs
@@ -41,7 +41,7 @@ public class InstallChunkWriter : IDisposable
             {
                 int index = int.Parse(Path.GetFileName(file).AsSpan()[4..][..^4]);
                 m_casIndex = Math.Max(index, m_casIndex);
-                File.CreateSymbolicLink(Path.Combine(m_dir, $"cas_{index:D2}.cas"), file);
+                Frosty.Sdk.Utils.Utils.File.CreateSymbolicLink(Path.Combine(m_dir, $"cas_{index:D2}.cas"), file);
             }
         }
 

--- a/FrostyModSupport/FrostyModExecutor.cs
+++ b/FrostyModSupport/FrostyModExecutor.cs
@@ -187,7 +187,7 @@ public partial class FrostyModExecutor
             if (!File.Exists(modPath))
             {
                 Directory.CreateDirectory(Directory.GetParent(modPath)!.FullName);
-                File.CreateSymbolicLink(modPath, file);
+                Frosty.Sdk.Utils.Utils.File.CreateSymbolicLink(modPath, file);
             }
         }
 
@@ -200,13 +200,13 @@ public partial class FrostyModExecutor
                 {
                     string destPath = Path.Combine(inModPackPath, source.Path);
                     Directory.CreateDirectory(Directory.GetParent(destPath)!.FullName);
-                    Directory.CreateSymbolicLink(destPath,
+                    Frosty.Sdk.Utils.Utils.Directory.CreateSymbolicLink(destPath,
                         Path.Combine(FileSystemManager.BasePath, source.Path));
                 }
 
                 if (source.Path != FileSystemSource.Base.Path && source.Path.Contains("Data"))
                 {
-                    File.CreateSymbolicLink(
+                    Frosty.Sdk.Utils.Utils.File.CreateSymbolicLink(
                         Path.Combine(inModPackPath, source.Path.Replace("/Data", string.Empty),
                             "package.mft"),
                         Path.Combine(FileSystemManager.BasePath, source.Path.Replace("/Data", string.Empty),

--- a/FrostyModSupport/SuperBundleActions/Dynamic2018.cs
+++ b/FrostyModSupport/SuperBundleActions/Dynamic2018.cs
@@ -896,7 +896,7 @@ public partial class FrostyModExecutor
                 string sbPath = tocPath.Replace(".toc", ".sb");
                 if (File.Exists(sbPath))
                 {
-                    File.CreateSymbolicLink(modifiedToc.FullName.Replace(".toc", ".sb"), sbPath);
+                    Frosty.Sdk.Utils.Utils.File.CreateSymbolicLink(modifiedToc.FullName.Replace(".toc", ".sb"), sbPath);
                 }
             }
         }

--- a/FrostyModSupport/SuperBundleActions/Manifest2019.cs
+++ b/FrostyModSupport/SuperBundleActions/Manifest2019.cs
@@ -798,7 +798,7 @@ public partial class FrostyModExecutor
                 string sbPath = tocPath.Replace(".toc", ".sb");
                 if (File.Exists(sbPath))
                 {
-                    File.CreateSymbolicLink(modifiedToc.FullName.Replace(".toc", ".sb"), sbPath);
+                    Frosty.Sdk.Utils.Utils.File.CreateSymbolicLink(modifiedToc.FullName.Replace(".toc", ".sb"), sbPath);
                 }
             }
         }

--- a/FrostySdk/Managers/ResourceManager.cs
+++ b/FrostySdk/Managers/ResourceManager.cs
@@ -86,7 +86,7 @@ public static class ResourceManager
             string ext = Path.GetExtension(libOodle);
             string path = Path.Combine(thirdPartyPath, $"oo2core{ext}");
             File.Delete(path);
-            File.CreateSymbolicLink(path, libOodle);
+            Utils.Utils.File.CreateSymbolicLink(path, libOodle);
 
             // get major version X (2.X.y) from dll name (oo2core_X_win64.dll)
             CompressionOodle.MajorVersion = int.Parse(Regex.Match(libOodle, "oo2core_(.*?)_win").Groups[1].Value);
@@ -95,7 +95,7 @@ public static class ResourceManager
             {
                 string oodleHack = Path.Combine(thirdPartyPath, "oo2core.so");
                 File.Delete(oodleHack);
-                File.CreateSymbolicLink(oodleHack, Path.Combine(thirdPartyPath, "liblinoodle.so"));
+                Utils.Utils.File.CreateSymbolicLink(oodleHack, Path.Combine(thirdPartyPath, "liblinoodle.so"));
             }
 
             break;

--- a/FrostySdk/Utils/Utils.cs
+++ b/FrostySdk/Utils/Utils.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using Frosty.Sdk.Ebx;
 using Frosty.Sdk.IO;
@@ -111,5 +114,75 @@ public static class Utils
         } while (ulongRand > max - (max % uRange + 1) % uRange);
 
         return (ulongRand % uRange + min) | 1;
+    }
+
+    public static class File
+    {
+        public static FileSystemInfo CreateSymbolicLink(string inPath, string inPathToTarget)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // windows is ass and needs admin rights for symlinks
+                ProcessStartInfo startInfo = new()
+                {
+                    FileName = "cmd.exe",
+                    Arguments = $"/c mklink \"{inPath}\" \"{inPathToTarget}\"",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    Verb = "runas"
+                };
+
+                using (Process? process = Process.Start(startInfo))
+                {
+                    process?.WaitForExit();
+
+                    if (process?.ExitCode != 0)
+                    {
+                        string? error = process?.StandardError.ReadToEnd();
+                        throw new Exception($"Faile to create symbolic link: {error}");
+                    }
+
+                    return new FileInfo(inPath);
+                }
+            }
+            return System.IO.File.CreateSymbolicLink(inPath, inPathToTarget);
+        }
+    }
+
+    public static class Directory
+    {
+        public static FileSystemInfo CreateSymbolicLink(string inPath, string inPathToTarget)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // windows is ass and needs admin rights for symlinks
+                ProcessStartInfo startInfo = new()
+                {
+                    FileName = "cmd.exe",
+                    Arguments = $"/c mklink /D \"{inPath}\" \"{inPathToTarget}\"",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    Verb = "runas"
+                };
+
+                using (Process? process = Process.Start(startInfo))
+                {
+                    process?.WaitForExit();
+
+                    if (process?.ExitCode != 0)
+                    {
+                        string? error = process?.StandardError.ReadToEnd();
+                        throw new Exception($"Faile to create symbolic link: {error}");
+                    }
+
+                    return new DirectoryInfo(inPath);
+                }
+            }
+            return System.IO.Directory.CreateSymbolicLink(inPath, inPathToTarget);
+        }
     }
 }


### PR DESCRIPTION
Use Utils.File/Directory.CreateSymbolicLink to not crash when not having admin rights in windows. Closes #34 